### PR TITLE
Handle statements without payment details

### DIFF
--- a/lib/adp-downloader/downloader.rb
+++ b/lib/adp-downloader/downloader.rb
@@ -17,19 +17,15 @@ module ADPDownloader
       response["payStatements"].map { |json| PayStatement.new(json) }
     end
 
-    def download_statement_files(statement)
-      @http_client.download(full_url(statement.details_url), statement.json)
-      @http_client.download(full_url(statement.image_url), statement.pdf)
-    end
-
-    def downloaded?(statement)
-      File.exists? statement.pdf and File.exists? statement.json
-    end
-
     def download_or_skip_statement(statement)
-      if not downloaded? statement
-        puts "Saving #{statement.pay_date} - #{statement.id}..."
-        download_statement_files(statement)
+      unless File.exists? statement.json or statement.details_url.nil?
+        puts "Saving #{statement.json}..."
+        @http_client.download(full_url(statement.details_url), statement.json, true)
+      end
+
+      unless File.exists? statement.pdf
+        puts "Saving #{statement.pdf}..."
+        @http_client.download(full_url(statement.image_url), statement.pdf)
       end
     end
 

--- a/lib/adp-downloader/http_client.rb
+++ b/lib/adp-downloader/http_client.rb
@@ -20,8 +20,11 @@ module ADPDownloader
       @agent.post(url, data)
     end
 
-    def download(url, save_path = nil)
+    def download(url, save_path = nil, json = false)
       contents = @agent.get(url).body
+      if json
+        contents = JSON.pretty_generate(JSON.parse(contents))
+      end
       File.open(save_path, 'w') {|f| f.write(contents)} if save_path
       contents
     end

--- a/lib/adp-downloader/pay_statement.rb
+++ b/lib/adp-downloader/pay_statement.rb
@@ -5,7 +5,8 @@ module ADPDownloader
     end
 
     def id
-      File.basename(@data["payDetailUri"]["href"])
+      path = File.basename(@data["statementImageUri"]["href"])
+      path.gsub(/\.pdf/, '')
     end
 
     def pay_date
@@ -14,23 +15,35 @@ module ADPDownloader
 
     def image_url
       path = @data["statementImageUri"]["href"]
-			path.gsub(/^\/l2/, '') # remove first characters, since it's incorrect o.O
+      path.gsub(/^\/l2/, '') # remove first characters, since it's incorrect o.O
     end
 
     def details_url
-      @data["payDetailUri"]["href"]
+      if @data["payDetailUri"] && @data["payDetailUri"]["href"]
+        return @data["payDetailUri"]["href"]
+      else
+        return nil
+      end
+    end
+
+    def adjustment?
+      @data["payAdjustmentIndicator"]
     end
 
     def filename
-      "#{@data["payDate"]}-#{id}"
+      if adjustment?
+        return "#{@data["payDate"]} #{id} - Adjustment"
+      else
+        return "#{@data["payDate"]} #{id}"
+      end
     end
 
     def pdf
-      "#{filename}.pdf"
+      "pdf/#{filename}.pdf"
     end
 
     def json
-      "#{filename}.json"
+      "json/#{filename}.json"
     end
   end
 end

--- a/lib/adp-downloader/version.rb
+++ b/lib/adp-downloader/version.rb
@@ -1,3 +1,3 @@
 module ADPDownloader
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Thank you for putting this up! I cannot begin to describe the frustration that ADP's system has brought me.

I've never touched Ruby code before, so it's likely this patch is unidiomatic or just plain wrong in some ways. Let me know what I can do to make this acceptable for upstream, I'd really rather not maintain a fork so I'm motivated to get this pull request to your liking.

Important Note: This patch changes the naming scheme!

1. If `payDetailUri` is missing (which can be the case when you get a pay adjustment or reimbursement) this script fails. This patch handles missing `payDetailUri` data.
2. Because of the above, the current identifier used for file names is not adequate because it's not always present. This patch uses a different id for file names which is consistent across all records.
3. Pretty print JSON

Not all items will have a `payDetailUri`. Specifically, if the pay statement
is an adjustment (ie. raise) or reimbursement, there will exist only a
`statementImageUri`. This patch handles the scenario by using the last path
component of the `statementImageUri` as the `id` instead of the last path
component of `payDetailUri`. The later appears to always be an integer while
the former is a string whose first three or so characters appear to identify
the company. Because this string identifier is always present (while the
integer version is absent when `payDetailUri` is absent), I think this is
probably the most appropriate for use in the file name.